### PR TITLE
Fix tracker

### DIFF
--- a/src/tracker/Tracker.coffee
+++ b/src/tracker/Tracker.coffee
@@ -21,12 +21,12 @@ class Tracker
 
 
   checkInitialized: ->
-    Promise.resolve(true) if @initConfirmed
+    return Promise.resolve(true) if @initConfirmed
     logger.code.debug("Trying to connect to trackerdb on #{'services.tracker.host'}")
     delay = 5000
     @db.query('SELECT * FROM `tracker` LIMIT 1;')
     .then(=>
-      true
+      @initConfirmed = true
     ).catch((error)=>
       if error.code is 'ER_NO_SUCH_TABLE'
         false

--- a/src/tracker/Tracker.coffee
+++ b/src/tracker/Tracker.coffee
@@ -29,9 +29,6 @@ class Tracker
     ).catch((error)=>
       if error.code is 'ER_NO_SUCH_TABLE'
         false
-      else if error.code is 'ER_BAD_DB_ERROR'
-        logger.WARN "Database trackerdb was not valid: #{error}"
-        Promise.reject("Tracker could not connect to trackerdb database")
       else
         if @tries-- > 0
           Promise.delay(@delay).then(=>@checkInitialized())

--- a/src/tracker/Tracker.coffee
+++ b/src/tracker/Tracker.coffee
@@ -9,7 +9,7 @@ class Tracker
     @tries = 10
     @delay = 5000
     @db = mysql()
-    @dbName = tracker.database
+    @initConfirmed = false
     @db.configure({
       host     : tracker.host
       port     : tracker.port
@@ -21,6 +21,7 @@ class Tracker
 
 
   checkInitialized: ->
+    Promise.resolve(true) if @initConfirmed
     logger.code.debug("Trying to connect to trackerdb on #{'services.tracker.host'}")
     delay = 5000
     @db.query('SELECT * FROM `tracker` LIMIT 1;')
@@ -70,6 +71,8 @@ class Tracker
           INDEX `to_index` (`to` ASC)
           ) ENGINE=InnoDB DEFAULT CHARSET=utf8;'
         )
+      ).then(=>
+        @initConfirmed = true
       )
     )
 

--- a/src/tracker/TrackerCtrl.coffee
+++ b/src/tracker/TrackerCtrl.coffee
@@ -5,6 +5,8 @@ Promise       = require('bluebird')
 logger        = require('logger')
 operationSort = require('operationSort')
 
+trackers = {}
+
 bus.private('write').retrieve('tracker', 'user', 'project').on((req, tracker, user, project) ->
   if tracker?
     req.payload.operations.sort(operationSort)
@@ -16,5 +18,7 @@ bus.private('history').retrieve('tracker').on((req, tracker) ->
   tracker.getHistoryFor(req)
 
 bus.provide('tracker').retrieve('project').on((req, project) ->
-  Promise.resolve(new Tracker(project.tracker))
+  if not trackers[project.id]?
+    trackers[project.id] = new Tracker(project.tracker)
+  trackers[project.id]
 ))


### PR DESCRIPTION
- Assumes that trackerdb database exists, the docker image we use creates it so it needn't be our responsibility. This removes unnecessary complexity from the initialization
- Only using one instance of the tracker per project opposed to recreating it for each operation
- Shortcutting database initialisation check for that one instance