### PR TITLE
blocking on bus if final is true

### DIFF
--- a/src/core/EventBus.coffee
+++ b/src/core/EventBus.coffee
@@ -18,8 +18,14 @@ class EventBus
     # Sort based on priority
     sorted = notify.sort((a,b) -> a.after(b))
 
+    tillFinal = []
+    for l in sorted
+      tillFinal.push(l)
+      if l.isFinal()
+        break
+
     # Promise.mapSeries runs promises sequentially (as opposed to Promise.map)
-    Promise.mapSeries(sorted, (listener) ->
+    Promise.mapSeries(tillFinal, (listener) ->
       listener.call(args...)
     ).then((result) ->
 

--- a/src/core/EventListener.coffee
+++ b/src/core/EventListener.coffee
@@ -6,6 +6,7 @@ class EventListener
     @_provide  = []
     @_priority = 0
     @_enabled  = true
+    @_final = false
 
   priority: (value) ->
     @_priority = value
@@ -29,6 +30,13 @@ class EventListener
   require: (args...) ->
     @_require.push(a) for a in args
     @
+
+  final: (final) ->
+    @_final = final
+    @
+
+  isFinal: ->
+    @_final
 
   call: (args...) ->
     if not @_enabled


### PR DESCRIPTION
ie, doing this in a plugin you'll block the 'query' bus on server, the priority still active:

`weaverBus.private('query').priority(200).final(true).retrieve('user', 'database').on((req, user, database) ->` 