### PR TITLE
Adds function permission scheme

### DIFF
--- a/config/default.coffee
+++ b/config/default.coffee
@@ -56,7 +56,7 @@ module.exports =
       agentAddress: 'localhost'
 
   logging:
-    console: 'silly'
+    console: 'error'
     file:    'warn'
     logFilePath:
       config: './logs/weaver.config'

--- a/config/default.coffee
+++ b/config/default.coffee
@@ -56,7 +56,7 @@ module.exports =
       agentAddress: 'localhost'
 
   logging:
-    console: 'error'
+    console: 'silly'
     file:    'warn'
     logFilePath:
       config: './logs/weaver.config'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaver-server",
-  "version": "2.3.2-beta.0",
+  "version": "2.3.2-beta.1",
   "description": "Module providing a Weaver-compatible API server",
   "author": {
     "name": "Mohamad Alamili",

--- a/src/auth/AclCtrl.coffee
+++ b/src/auth/AclCtrl.coffee
@@ -1,12 +1,15 @@
 bus         = require('WeaverBus')
 AclService  = require('AclService')
+logger      = require('logger')
 
 bus.private('acl.create').retrieve('user').require('acl').on((req, user, acl) ->
   AclService.createACLFromServer(acl, user)
 )
 
 bus.private('acl.read').retrieve('user').require('id').on((req, user, id) ->
+  logger.code.silly "Reading ACL with id #{id}"
   AclService.assertACLReadPermission(user, id)
+  logger.code.silly "Reading ACL with id #{id} read check passed"
   AclService.getACL(id)
 )
 

--- a/src/auth/AclService.coffee
+++ b/src/auth/AclService.coffee
@@ -58,6 +58,12 @@ class AclService extends LokiService
       @acl.update(delAcl)
     acl
 
+  checkProjectAcl: (projectId) ->
+    logger.code.info "Checking existence of function ACLs for project: #{projectId}"
+    for f in @projectFunctionACLs
+      id = @getProjectFunctionAclId(projectId, f)
+      @createFunctionACL(id) if !getACL(id)?
+
   createACL: (objectId, user) ->
     acl =
       id:          cuid()

--- a/src/auth/AclService.coffee
+++ b/src/auth/AclService.coffee
@@ -56,6 +56,7 @@ class AclService extends LokiService
 
     @objects.insert({id: objectId, acl: acl.id})
     aclDoc = @acl.insert(acl)
+    logger.code.silly "Created ACL with id #{acl.id} for object #{objectId}"
     aclDoc
 
   createACLFromServer: (aclServerObject) ->
@@ -68,6 +69,7 @@ class AclService extends LokiService
       roleRead    : aclServerObject._roleRead
       roleWrite   : aclServerObject._roleWrite
 
+    logger.code.silly "Created ACL with id #{acl.id} from aclServerObject"
     @acl.insert(acl)
 
 
@@ -78,6 +80,7 @@ class AclService extends LokiService
 
   getACLByObject: (objectId) ->
     object = @objects.findOne({id: objectId})
+    logger.code.debug "getACLByObject(#{objectId}): #{object}"
     @getACL(object.acl)
 
 

--- a/src/auth/AclService.coffee
+++ b/src/auth/AclService.coffee
@@ -52,8 +52,10 @@ class AclService extends LokiService
   createProjectACLs: (projectId, user) ->
     logger.usage.info "Creating ACLs for project #{projectId}"
     acl = @createACL(projectId, user)
-    delAcl = @createFunctionACL(@getProjectFunctionAclId(projectId, 'delete-project'))
-    delAcl.userWrite.push(user.userId)
+    for projectFunctionAcl in @projectFunctionACLs
+      delAcl = @createFunctionACL(@getProjectFunctionAclId(projectId, projectFunctionAcl))
+      delAcl.userWrite.push(user.userId)
+      @acl.update(delAcl)
     acl
 
   createACL: (objectId, user) ->

--- a/src/auth/AclService.coffee
+++ b/src/auth/AclService.coffee
@@ -50,7 +50,7 @@ class AclService extends LokiService
     acl =
       id:          cuid()
       userRead:    []
-      userWrite:   [user.username]
+      userWrite:   [user.userId]
       roleRead:    []
       roleWrite:   []
       publicRead:  false
@@ -77,7 +77,7 @@ class AclService extends LokiService
 
   getACL: (aclId) ->
     result = @acl.findOne({id: aclId})
-    logger.code.debug "getACL(#{aclId}) result: #{result}"
+    logger.code.debug "getACL(#{aclId}) result: #{JSON.stringify(result)}"
     result
 
   getACLByObject: (objectId) ->

--- a/src/auth/AclService.coffee
+++ b/src/auth/AclService.coffee
@@ -8,7 +8,9 @@ logger      = require('logger')
 
 class AclService extends LokiService
   serverFunctionACLs: [
-    'create-projects'
+    'create-projects',
+    'modify-acl',
+    'create-users'
   ]
 
   projectFunctionACLs: [

--- a/src/auth/AclService.coffee
+++ b/src/auth/AclService.coffee
@@ -46,6 +46,12 @@ class AclService extends LokiService
 
     @acl.insert(acl)
 
+  createProjectACLs: (projectId, user) ->
+    logger.usage.info "Creating ACLs for project #{projectId}"
+    acl = @createACL(projectId, user)
+
+    acl
+
   createACL: (objectId, user) ->
     acl =
       id:          cuid()

--- a/src/auth/AclService.coffee
+++ b/src/auth/AclService.coffee
@@ -83,6 +83,8 @@ class AclService extends LokiService
 
   updateACL: (aclServerObject) ->
     acl = @acl.findOne({id: aclServerObject._id})
+    logger.usage.debug "Updating acl #{acl.id}"
+
     acl.publicRead  = aclServerObject._publicRead
     acl.publicWrite = aclServerObject._publicWrite
     acl.userRead    = aclServerObject._userRead
@@ -111,6 +113,7 @@ class AclService extends LokiService
 
   assertACLPermission: (user, aclId, readOnly) ->
     return if user.isAdmin()
+    logger.usage.silly "Checking acl access for user #{user.username} on #{aclId}"
 
     acl = @getACL(aclId)
     allowedUsers = @getAllowedUsers(acl, readOnly)

--- a/src/auth/AclService.coffee
+++ b/src/auth/AclService.coffee
@@ -31,12 +31,12 @@ class AclService extends LokiService
   createServerFunctionACLs: ->
     logger.code.debug "Initializing server function ACLs"
     for functionACL in @serverFunctionACLs
-      @createServerFunctionACL(functionACL) if !@getACL(functionACL)?
+      @createFunctionACL(functionACL) if !@getACL(functionACL)?
 
-  createServerFunctionACL: (serverFunctionACL) ->
-    logger.code.debug "Creating server function ACL: #{serverFunctionACL}"
+  createFunctionACL: (functionACL) ->
+    logger.code.debug "Creating server function ACL: #{functionACL}"
     acl =
-      id: serverFunctionACL
+      id: functionACL
       userRead: []
       userWrite: []
       roleRead: []
@@ -46,10 +46,14 @@ class AclService extends LokiService
 
     @acl.insert(acl)
 
+  getProjectFunctionAclId: (projectId, functionname) ->
+    "project-#{projectId}-function-#{functionname}"
+
   createProjectACLs: (projectId, user) ->
     logger.usage.info "Creating ACLs for project #{projectId}"
     acl = @createACL(projectId, user)
-
+    delAcl = @createFunctionACL(@getProjectFunctionAclId(projectId, 'delete-project'))
+    delAcl.userWrite.push(user.userId)
     acl
 
   createACL: (objectId, user) ->

--- a/src/project/ProjectCtrl.coffee
+++ b/src/project/ProjectCtrl.coffee
@@ -43,7 +43,7 @@ bus.private('project.create').retrieve('user').require('id', 'name').on((req, us
   ProjectPool.create(id).then((project) ->
 
     # Create an ACL for this user to set on the project
-    acl = AclService.createACL(id, user)
+    acl = AclService.createProjectACLs(id, user)
     ProjectService.create(id, name, project.database, acl.id, project.fileServer, project.tracker)
 
     return acl

--- a/src/project/ProjectCtrl.coffee
+++ b/src/project/ProjectCtrl.coffee
@@ -29,7 +29,7 @@ bus.private('project').on((req) ->
 )
 
 bus.private('project.create').retrieve('user').require('id', 'name').on((req, user, id, name) ->
-  user.isAdmin() or AclService.assertACLWritePermission(user, 'create-projects')
+  AclService.assertACLWritePermission(user, 'create-projects')
 
   ProjectPool.create(id).then((project) ->
 

--- a/src/project/ProjectCtrl.coffee
+++ b/src/project/ProjectCtrl.coffee
@@ -29,6 +29,7 @@ bus.private('project').on((req) ->
 )
 
 bus.private('project.create').retrieve('user').require('id', 'name').on((req, user, id, name) ->
+  user.isAdmin() or AclService.assertACLWritePermission(user, 'create-projects')
 
   ProjectPool.create(id).then((project) ->
 

--- a/src/project/ProjectCtrl.coffee
+++ b/src/project/ProjectCtrl.coffee
@@ -50,7 +50,9 @@ bus.private('project.create').retrieve('user').require('id', 'name').on((req, us
   )
 )
 
-bus.private('project.delete').retrieve('project', 'database', 'minio', 'tracker').on((req, project, database, minio, tracker) ->
+bus.private('project.delete').retrieve('user', 'project', 'database', 'minio', 'tracker').on((req, user, project, database, minio, tracker) ->
+  AclService.assertACLWritePermission(user, AclService.getProjectFunctionAclId(project.id, 'delete-project'))
+
   logger.usage.info "Deleting project with id #{project.id}"
   Promise.all([
     tracker.wipe()

--- a/src/project/ProjectCtrl.coffee
+++ b/src/project/ProjectCtrl.coffee
@@ -42,6 +42,7 @@ bus.private('project.create').retrieve('user').require('id', 'name').on((req, us
 )
 
 bus.private('project.delete').retrieve('project', 'database', 'minio', 'tracker').on((req, project, database, minio, tracker) ->
+  logger.usage.info "Deleting project with id #{project.id}"
   Promise.all([
     tracker.wipe()
     database.wipe()
@@ -60,12 +61,14 @@ bus.internal('getMinioForProject').on((project) ->
 
 # Create a snapshot with write operations for the project
 bus.private('snapshot').retrieve('project').on((req, project) ->
+  logger.usage.info "Generating snapshot for project with id #{project.id}"
   database = new DatabaseService(project.database)
   database.snapshot()
 )
 
 # Wipe single project
 bus.public('project.wipe').retrieve('project').on((req, project) ->
+  logger.usage.info "Wiping project with id #{project.id}"
   database = new DatabaseService(project.database)
   database.wipe()
 )
@@ -73,7 +76,6 @@ bus.public('project.wipe').retrieve('project').on((req, project) ->
 
 # Wipe all projects
 bus.public('projects.wipe').enable(config.get('application.wipe')).on((req) ->
-
   logger.usage.info "Wiping all projects"
 
   endpoints = (p.database for p in ProjectService.all())

--- a/src/project/ProjectService.coffee
+++ b/src/project/ProjectService.coffee
@@ -2,6 +2,7 @@ LokiService = require('LokiService')
 cuid        = require('cuid')
 _           = require('lodash')
 logger      = require('logger')
+AclService  = require('AclService')
 
 class ProjectService extends LokiService
 
@@ -31,5 +32,13 @@ class ProjectService extends LokiService
   all: ->
     @projects.find()
 
+  load: ->
+    super().then(=>
+      @checkProjectAcls()
+    )
+
+  checkProjectAcls: ->
+    for project in @all
+      AclService.checkProjectAcl(project.id)
 
 module.exports = new ProjectService()


### PR DESCRIPTION
This adds two levels of function ACLs:
- server: These permissions are for operations which are server-wide
- projects: These project specific permissions only apply in a single project

This also fixes some previous problems with write access not being provided by default to the user that created the project.

In general, this is the groundwork for more specific changes to the permission scheme, the end goal of this branch is that delete-project cannot be used by every user that has write access to it.

For tests, see the accompanying SDK PR: https://github.com/weaverplatform/weaver-sdk-js/pull/94