### PR TITLE
Improve connector version messaging

### DIFF
--- a/src/core/ClientVersionChecker.coffee
+++ b/src/core/ClientVersionChecker.coffee
@@ -44,7 +44,7 @@ class ClientVersionChecker
     if !@connectorVersion?
       database = new DatabaseService(config.get('services.database.url'))
       database.base().then((data)=>
-        data.version
+        @lastKnownConnectorVersion = data.version
       )
     else
       Promise.resolve(@connectorVersion)

--- a/src/core/ClientVersionChecker.coffee
+++ b/src/core/ClientVersionChecker.coffee
@@ -27,7 +27,7 @@ class ClientVersionChecker
       logger.usage.debug "Client with required server version #{versionRequirement}"
       true
     else
-      logger.usage.warn "Server does not satisfy required version #{versionRequirement}"
+      logger.usage.warn "Server does not satisfy client required version #{versionRequirement}"
       false
 
   connectorSatisfies: (versionRequirement) ->
@@ -36,7 +36,7 @@ class ClientVersionChecker
         logger.usage.debug "Client with required connector version #{versionRequirement}"
         true
       else
-        logger.usage.warn "Connector #{connectorVersion} does not satisfy required version #{versionRequirement}"
+        logger.usage.warn "Connector #{connectorVersion} does not satisfy client required version #{versionRequirement}"
         false
     )
 

--- a/src/core/ClientVersionChecker.coffee
+++ b/src/core/ClientVersionChecker.coffee
@@ -36,7 +36,7 @@ class ClientVersionChecker
         logger.usage.debug "Client with required connector version #{versionRequirement}"
         true
       else
-        logger.usage.warn "Connector does not satisfy required version #{versionRequirement}"
+        logger.usage.warn "Connector #{connectorVersion} does not satisfy required version #{versionRequirement}"
         false
     )
 

--- a/src/core/SocketComm.coffee
+++ b/src/core/SocketComm.coffee
@@ -20,7 +20,7 @@ class Socket
       else
       @versionChecker.connectorSatisfies(socket.handshake.query.requiredConnectorVersion).then((checkResult) =>
         if !checkResult
-          next(new Error("Connector version #{@versionChecker.connectorVersion} does not satisfy '#{socket.handshake.query.requiredConnectorVersion}'"))
+          next(new Error("Connector version #{@versionChecker.lastKnownConnectorVersion} does not satisfy '#{socket.handshake.query.requiredConnectorVersion}'"))
         else
           next()
       )


### PR DESCRIPTION
Previously feedback was that version undefined did not satisfy a required version as the version was not definied in a static way, but that field was used for feedback anyway. This should be clearer. Also the connector now logs the retrieved version before rejecting.